### PR TITLE
Make embedded-sensors and async optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,15 @@ rust-version = "1.83.0"
 [dependencies]
 bilge = "0.2.0"
 embedded-hal = "1.0.0"
-embedded-hal-async = "1.0.0"
-embedded-sensors = { git = "https://github.com/OpenDevicePartnership/embedded-sensors" }
-embedded-sensors-async = { git = "https://github.com/OpenDevicePartnership/embedded-sensors" }
+embedded-hal-async = { version = "1.0.0", optional = true }
+embedded-sensors = { git = "https://github.com/OpenDevicePartnership/embedded-sensors", optional = true }
+embedded-sensors-async = { git = "https://github.com/OpenDevicePartnership/embedded-sensors", optional = true }
+
+[features]
+full = [ "async", "embedded-sensors", "embedded-sensors-async" ]
+async = [ "dep:embedded-hal-async" ]
+embedded-sensors = [ "dep:embedded-sensors" ]
+embedded-sensors-async = [ "dep:embedded-sensors-async" ]
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"

--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -1,7 +1,10 @@
 //! Tmp108 Async API
 use core::future::Future;
 
+#[cfg(feature = "embedded-sensors-async")]
 use embedded_sensors_async::sensor;
+
+#[cfg(feature = "embedded-sensors-async")]
 use embedded_sensors_async::temperature::{DegreesCelsius, TemperatureSensor};
 
 use super::{Configuration, ConversionMode, ConversionRate, Register, A0};
@@ -220,6 +223,36 @@ impl<I2C: embedded_hal_async::i2c::I2c, DELAY: embedded_hal_async::delay::DelayN
     }
 }
 
+/// Tmp108 Errors
+#[derive(Debug)]
+pub enum Error<E: embedded_hal_async::i2c::Error> {
+    /// I2C Bus Error
+    Bus(E),
+}
+
+#[cfg(feature = "embedded-sensors-async")]
+impl<E: embedded_hal_async::i2c::Error> sensor::Error for Error<E> {
+    fn kind(&self) -> sensor::ErrorKind {
+        sensor::ErrorKind::Other
+    }
+}
+
+#[cfg(feature = "embedded-sensors-async")]
+impl<I2C: embedded_hal_async::i2c::I2c, DELAY: embedded_hal_async::delay::DelayNs> sensor::ErrorType
+    for Tmp108<I2C, DELAY>
+{
+    type Error = Error<I2C::Error>;
+}
+
+#[cfg(feature = "embedded-sensors-async")]
+impl<I2C: embedded_hal_async::i2c::I2c, DELAY: embedded_hal_async::delay::DelayNs> TemperatureSensor
+    for Tmp108<I2C, DELAY>
+{
+    async fn temperature(&mut self) -> Result<DegreesCelsius, Self::Error> {
+        self.temperature().await.map_err(Error::Bus)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::{Hysteresis, Polarity, ThermostatMode};
@@ -326,32 +359,5 @@ mod tests {
 
         let mut mock = tmp.destroy();
         mock.done();
-    }
-}
-
-/// Tmp108 Errors
-#[derive(Debug)]
-pub enum Error<E: embedded_hal_async::i2c::Error> {
-    /// I2C Bus Error
-    Bus(E),
-}
-
-impl<E: embedded_hal_async::i2c::Error> sensor::Error for Error<E> {
-    fn kind(&self) -> sensor::ErrorKind {
-        sensor::ErrorKind::Other
-    }
-}
-
-impl<I2C: embedded_hal_async::i2c::I2c, DELAY: embedded_hal_async::delay::DelayNs> sensor::ErrorType
-    for Tmp108<I2C, DELAY>
-{
-    type Error = Error<I2C::Error>;
-}
-
-impl<I2C: embedded_hal_async::i2c::I2c, DELAY: embedded_hal_async::delay::DelayNs> TemperatureSensor
-    for Tmp108<I2C, DELAY>
-{
-    async fn temperature(&mut self) -> Result<DegreesCelsius, Self::Error> {
-        self.temperature().await.map_err(Error::Bus)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,10 @@
 
 mod registers;
 pub use registers::*;
+
+#[cfg(feature = "async")]
 pub mod asynchronous;
+
 pub mod blocking;
 
 /// A0 pin logic level representation.


### PR DESCRIPTION
Instead of unconditionally adding embedded-hal-async and embedded-sensors, let the user decide if they need it.