### PR TITLE
Use public version of embedded-sensors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,14 +23,14 @@ rust-version = "1.83.0"
 bilge = "0.2.0"
 embedded-hal = "1.0.0"
 embedded-hal-async = { version = "1.0.0", optional = true }
-embedded-sensors = { git = "https://github.com/OpenDevicePartnership/embedded-sensors", optional = true }
-embedded-sensors-async = { git = "https://github.com/OpenDevicePartnership/embedded-sensors", optional = true }
+embedded-sensors-hal = { version = "0.1.0", optional = true }
+embedded-sensors-hal-async = { version = "0.1.0", optional = true }
 
 [features]
-full = [ "async", "embedded-sensors", "embedded-sensors-async" ]
+full = [ "async", "embedded-sensors-hal", "embedded-sensors-hal-async" ]
 async = [ "dep:embedded-hal-async" ]
-embedded-sensors = [ "dep:embedded-sensors" ]
-embedded-sensors-async = [ "dep:embedded-sensors-async" ]
+embedded-sensors-hal = [ "dep:embedded-sensors-hal" ]
+embedded-sensors-hal-async = [ "dep:embedded-sensors-hal-async" ]
 
 [dev-dependencies]
 assert_approx_eq = "1.1.0"

--- a/deny.toml
+++ b/deny.toml
@@ -75,6 +75,7 @@ ignore = [
     #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
     #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
     { id = "RUSTSEC-2024-0370", reason = "proc-macro-error is unmaintained, no safe upgrade available, need upstream dependencies to migrate away from it." },
+    { id = "RUSTSEC-2024-0436", reason = "there are no suitable replacements for paste right now; paste has been archived as read-only. It only affects compile time concatenation in macros. We will allow it for now" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.

--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -1,10 +1,10 @@
 //! Tmp108 Async API
 use core::future::Future;
 
-#[cfg(feature = "embedded-sensors-async")]
-use embedded_sensors_async::sensor;
-#[cfg(feature = "embedded-sensors-async")]
-use embedded_sensors_async::temperature::{DegreesCelsius, TemperatureSensor};
+#[cfg(feature = "embedded-sensors-hal-async")]
+use embedded_sensors_hal_async::sensor;
+#[cfg(feature = "embedded-sensors-hal-async")]
+use embedded_sensors_hal_async::temperature::{DegreesCelsius, TemperatureSensor};
 
 use super::{Configuration, ConversionMode, ConversionRate, Register, A0};
 
@@ -229,21 +229,21 @@ pub enum Error<E: embedded_hal_async::i2c::Error> {
     Bus(E),
 }
 
-#[cfg(feature = "embedded-sensors-async")]
+#[cfg(feature = "embedded-sensors-hal-async")]
 impl<E: embedded_hal_async::i2c::Error> sensor::Error for Error<E> {
     fn kind(&self) -> sensor::ErrorKind {
         sensor::ErrorKind::Other
     }
 }
 
-#[cfg(feature = "embedded-sensors-async")]
+#[cfg(feature = "embedded-sensors-hal-async")]
 impl<I2C: embedded_hal_async::i2c::I2c, DELAY: embedded_hal_async::delay::DelayNs> sensor::ErrorType
     for Tmp108<I2C, DELAY>
 {
     type Error = Error<I2C::Error>;
 }
 
-#[cfg(feature = "embedded-sensors-async")]
+#[cfg(feature = "embedded-sensors-hal-async")]
 impl<I2C: embedded_hal_async::i2c::I2c, DELAY: embedded_hal_async::delay::DelayNs> TemperatureSensor
     for Tmp108<I2C, DELAY>
 {

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -1,9 +1,9 @@
 //! Tmp108 Blocking API
 
-#[cfg(feature = "embedded-sensors")]
-use embedded_sensors::sensor;
-#[cfg(feature = "embedded-sensors")]
-use embedded_sensors::temperature::{DegreesCelsius, TemperatureSensor};
+#[cfg(feature = "embedded-sensors-hal")]
+use embedded_sensors_hal::sensor;
+#[cfg(feature = "embedded-sensors-hal")]
+use embedded_sensors_hal::temperature::{DegreesCelsius, TemperatureSensor};
 
 use super::{Configuration, ConversionMode, ConversionRate, Register, A0};
 
@@ -227,19 +227,19 @@ pub enum Error<E: embedded_hal::i2c::Error> {
     Bus(E),
 }
 
-#[cfg(feature = "embedded-sensors")]
+#[cfg(feature = "embedded-sensors-hal")]
 impl<E: embedded_hal::i2c::Error> sensor::Error for Error<E> {
     fn kind(&self) -> sensor::ErrorKind {
         sensor::ErrorKind::Other
     }
 }
 
-#[cfg(feature = "embedded-sensors")]
+#[cfg(feature = "embedded-sensors-hal")]
 impl<I2C: embedded_hal::i2c::I2c, DELAY: embedded_hal::delay::DelayNs> sensor::ErrorType for Tmp108<I2C, DELAY> {
     type Error = Error<I2C::Error>;
 }
 
-#[cfg(feature = "embedded-sensors")]
+#[cfg(feature = "embedded-sensors-hal")]
 impl<I2C: embedded_hal::i2c::I2c, DELAY: embedded_hal::delay::DelayNs> TemperatureSensor for Tmp108<I2C, DELAY> {
     fn temperature(&mut self) -> Result<DegreesCelsius, Self::Error> {
         self.temperature().map_err(Error::Bus)


### PR DESCRIPTION
Instead of pointing to git repository, use the public version of the crate.