### PR TITLE
Fix set_high_limit docstring typo

### DIFF
--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -181,7 +181,7 @@ impl<I2C: embedded_hal_async::i2c::I2c, DELAY: embedded_hal_async::delay::DelayN
         Ok(Self::to_celsius(i16::from_be_bytes(raw)))
     }
 
-    /// Set temperature low limit register
+    /// Set temperature high limit register
     ///
     /// # Errors
     ///

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -179,7 +179,7 @@ impl<I2C: embedded_hal::i2c::I2c, DELAY: embedded_hal::delay::DelayNs> Tmp108<I2
         Ok(Self::to_celsius(i16::from_be_bytes(raw)))
     }
 
-    /// Set temperature low limit register
+    /// Set temperature high limit register
     ///
     /// # Errors
     ///


### PR DESCRIPTION
Fixes a typo in the docstring for `set_high_limit` (in both `asynchronous` and `blocking` modules).