### PR TITLE
Implement TemperatureThresholdWait trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmp108"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Felipe Balbi <febalbi@microsoft.com>"]
 repository = "https://github.com/OpenDevicePartnership/tmp108"
 license = "MIT"
@@ -24,7 +24,7 @@ bilge = "0.2.0"
 embedded-hal = "1.0.0"
 embedded-hal-async = { version = "1.0.0", optional = true }
 embedded-sensors-hal = { version = "0.1.0", optional = true }
-embedded-sensors-hal-async = { version = "0.1.0", optional = true }
+embedded-sensors-hal-async = { version = "0.2.0", optional = true }
 
 [features]
 full = [ "async", "embedded-sensors-hal", "embedded-sensors-hal-async" ]


### PR DESCRIPTION
This PR implements the `embedded-sensors` `TemperatureThresholdWait` trait.

Unfortunately requires breaking existing interface, even when `embedded-sensors-hal-async` feature is not enabled. The alternative is to duplicate a lot of code and have a feature gate for the version that has the generic `ALERT: embedded_hal_async::digital::Wait`, but that does not seem worth it.

The other alternative which I'm open to is making `wait_for_temperature_threshold` require an ALERT pin as an argument, thus the Tmp108 struct wouldn't need a generic field for it. I was unsure about this, as having to pass a pin instantiation around until it gets to the call site might not be very ergonomic. Curious if others feel this is the better route though.

Driver might also benefit from additional typestate so polarity and thermostat mode don't need to be checked at runtime, which I'm open to implementing as well.

Resolves #15 