### PR TITLE
Fix config register byte order

### DIFF
--- a/src/asynchronous.rs
+++ b/src/asynchronous.rs
@@ -470,8 +470,8 @@ mod tests {
     #[tokio::test]
     async fn read_write_configuration_register() {
         let expectations = vec![
-            Transaction::write_read(0x48, vec![0x01], vec![0x10, 0x22]),
-            Transaction::write(0x48, vec![0x01, 0xb0, 0xfe]),
+            Transaction::write_read(0x48, vec![0x01], vec![0x22, 0x10]),
+            Transaction::write(0x48, vec![0x01, 0xfe, 0xb0]),
         ];
 
         let mock = Mock::new(&expectations);
@@ -507,10 +507,10 @@ mod tests {
 
         // Sensor i2c bus mocks and expectations
         let i2c_expectations = vec![
-            Transaction::write(0x48, vec![0x01, 0x10, 0x26]),
+            Transaction::write(0x48, vec![0x01, 0x26, 0x10]),
             Transaction::write(0x48, vec![0x02, 0x19, 0x00]),
             Transaction::write(0x48, vec![0x03, 0x50, 0x00]),
-            Transaction::write_read(0x48, vec![0x01], vec![0x10, 0x26]),
+            Transaction::write_read(0x48, vec![0x01], vec![0x26, 0x10]),
             Transaction::write_read(0x48, vec![0x00], vec![0x50, 0x00]),
         ];
         let i2c_mock = Mock::new(&i2c_expectations);

--- a/src/blocking.rs
+++ b/src/blocking.rs
@@ -323,8 +323,8 @@ mod tests {
     #[test]
     fn read_write_configuration_register() {
         let expectations = vec![
-            Transaction::write_read(0x48, vec![0x01], vec![0x10, 0x22]),
-            Transaction::write(0x48, vec![0x01, 0xb0, 0xfe]),
+            Transaction::write_read(0x48, vec![0x01], vec![0x22, 0x10]),
+            Transaction::write(0x48, vec![0x01, 0xfe, 0xb0]),
         ];
 
         let mock = Mock::new(&expectations);

--- a/src/registers.rs
+++ b/src/registers.rs
@@ -47,6 +47,16 @@ pub struct LowLimit(u16);
 #[bitsize(16)]
 #[derive(DebugBits, FromBits, PartialEq, Clone, Copy)]
 pub struct Configuration {
+    reserved0_3: u4,
+
+    /// Hysteresis control.
+    pub hysteresis: Hysteresis,
+
+    reserved6: bool,
+
+    /// Polarity
+    pub polarity: Polarity,
+
     /// Conversion mode
     pub cm: ConversionMode,
 
@@ -64,21 +74,11 @@ pub struct Configuration {
 
     /// ID bit
     pub id: bool,
-
-    reserved0_3: u4,
-
-    /// Hysteresis control.
-    pub hysteresis: Hysteresis,
-
-    reserved6: bool,
-
-    /// Polarity
-    pub polarity: Polarity,
 }
 
 impl Default for Configuration {
     fn default() -> Self {
-        Self::from(0b0001_0000_0010_0010)
+        Self::from(0b0010_0010_0001_0000)
     }
 }
 
@@ -222,54 +222,54 @@ mod tests {
     #[test]
     fn default_configuration() {
         let cfg = Configuration::default();
-        assert_eq!(cfg.value, 0x1022);
+        assert_eq!(cfg.value, 0x2210);
     }
 
     #[test]
     fn modify_conversion_mode() {
         let cfg = Configuration::default().with_cm(ConversionMode::Shutdown);
-        assert_eq!(cfg.value, 0x1020);
+        assert_eq!(cfg.value, 0x2010);
     }
 
     #[test]
     fn modify_thermostat_mode() {
         let cfg = Configuration::default().with_tm(ThermostatMode::Interrupt);
-        assert_eq!(cfg.value, 0x1026);
+        assert_eq!(cfg.value, 0x2610);
     }
 
     #[test]
     fn modify_flag_low() {
         let cfg = Configuration::default().with_fl(true);
-        assert_eq!(cfg.value, 0x102a);
+        assert_eq!(cfg.value, 0x2a10);
     }
 
     #[test]
     fn modify_flag_high() {
         let cfg = Configuration::default().with_fh(true);
-        assert_eq!(cfg.value, 0x1032);
+        assert_eq!(cfg.value, 0x3210);
     }
 
     #[test]
     fn modify_conversion_rate() {
         let cfg = Configuration::default().with_cr(ConversionRate::Hertz16);
-        assert_eq!(cfg.value, 0x1062);
+        assert_eq!(cfg.value, 0x6210);
     }
 
     #[test]
     fn modify_id() {
         let cfg = Configuration::default().with_id(true);
-        assert_eq!(cfg.value, 0x10a2);
+        assert_eq!(cfg.value, 0xa210);
     }
 
     #[test]
     fn modify_hysteresis() {
         let cfg = Configuration::default().with_hysteresis(Hysteresis::FourCelsius);
-        assert_eq!(cfg.value, 0x3022);
+        assert_eq!(cfg.value, 0x2230);
     }
 
     #[test]
     fn modify_polarity() {
         let cfg = Configuration::default().with_polarity(Polarity::ActiveHigh);
-        assert_eq!(cfg.value, 0x9022);
+        assert_eq!(cfg.value, 0x2290);
     }
 }


### PR DESCRIPTION
The driver currently assumes byte 1 of the config register is the LSB and byte 2 is the MSB. This PR changes it to the correct order (byte 1 is MSB, byte 2 is LSB).

This was discovered after writing `Config::default()` to a TMP108 device. The device was not returning fresh temperature samples during periodic polling. Likely the device was in shutdown mode since the current default value written would be `0x1022` which would cause M1 and M0 bits to be set to `0b00` (shutdown mode).

This fix thus changes the default value to `0x2210` which makes the device operate as expected.