### PR TITLE
Update to embedded-sensors v0.3.0

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -162,7 +162,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        msrv: ["1.83"] # We're relying on namespaced-features, which
+        msrv: ["1.84"] # We're relying on namespaced-features, which
                        # was released in 1.60
                        #
                        # We also depend on `fixed' which requires rust
@@ -175,6 +175,8 @@ jobs:
                        # collapse_debuginfo
                        #
                        # embassy upstream switched to rust 1.83
+                       #
+                       # f32::abs moved to core from std
 
     name: ubuntu / ${{ matrix.msrv }}
     steps:

--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        msrv: ["1.83"] # We're relying on namespaced-features, which
+        msrv: ["1.84"] # We're relying on namespaced-features, which
                        # was released in 1.60
                        #
                        # We also depend on `fixed' which requires rust
@@ -48,6 +48,8 @@ jobs:
                        # collapse_debuginfo
                        #
                        # embassy upstream switched to rust 1.83
+                       #
+                       # f32::abs moved to core from std
     name: ubuntu / ${{ matrix.msrv }}
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmp108"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Felipe Balbi <febalbi@microsoft.com>"]
 repository = "https://github.com/OpenDevicePartnership/tmp108"
 license = "MIT"
@@ -17,14 +17,14 @@ include = [
 	"/LICENSE",
 ]
 edition = "2021"
-rust-version = "1.83.0"
+rust-version = "1.84.0"
 
 [dependencies]
 bilge = "0.2.0"
 embedded-hal = "1.0.0"
 embedded-hal-async = { version = "1.0.0", optional = true }
 embedded-sensors-hal = { version = "0.1.0", optional = true }
-embedded-sensors-hal-async = { version = "0.2.0", optional = true }
+embedded-sensors-hal-async = { version = "0.3.0", optional = true }
 
 [features]
 full = [ "async", "embedded-sensors-hal", "embedded-sensors-hal-async" ]


### PR DESCRIPTION
Updates to `embedded-sensors` v0.3.0, introducing breaking changes to the API requiring update of `tmp108` version from v0.2.0 to v0.3.0.

MSRV changed to 1.84 to be able to use f32::abs from core (which was moved from std). Alternatives are to use silent integer truncation instead of checking for float equality within an epsilon, but that might result in behavior caller does not expect.