### PR TITLE
update dependencies to solve security vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,15 +75,15 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "either"
@@ -174,9 +174,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "io-uring"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.174"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "memchr"
@@ -347,9 +347,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -365,21 +365,21 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "tmp108"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "assert_approx_eq",
  "bilge",
@@ -402,9 +402,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.46.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "io-uring",
@@ -428,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmp108"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["Felipe Balbi <febalbi@microsoft.com>"]
 repository = "https://github.com/OpenDevicePartnership/tmp108"
 license = "MIT"
@@ -35,7 +35,7 @@ embedded-sensors-hal-async = [ "dep:embedded-sensors-hal-async" ]
 [dev-dependencies]
 assert_approx_eq = "1.1.0"
 embedded-hal-mock = { version = "0.11.1", features = [ "embedded-hal-async" ] }
-tokio = { version = "1.37.0", features = [ "rt", "macros" ] }
+tokio = { version = "1.47.0", features = [ "rt", "macros" ] }
 
 [lints.rust]
 unsafe_code = "forbid"

--- a/deny.toml
+++ b/deny.toml
@@ -230,7 +230,7 @@ allow-git = []
 
 [sources.allow-org]
 # github.com organizations to allow git sources for
-github = ["OpenDevicePartnership"]
+github = []
 # gitlab.com organizations to allow git sources for
 gitlab = []
 # bitbucket.org organizations to allow git sources for


### PR DESCRIPTION
Sorts out this known vulnerability:

installed targets:
  x86_64-unknown-linux-musl
warning[unmatched-organization]: allowed 'github.com' organization  was not encountered
    ┌─ ./deny.toml:233:12
    │
233 │ github = ["OpenDevicePartnership"]
    │            ━━━━━━━━━━━━━━━━━━━━━ no crate source fell under this organization

error[vulnerability]: Out-of-bounds access in `get_disjoint_mut` due to incorrect bounds check
   ┌─ /github/workspace/Cargo.lock:43:1
   │
43 │ slab 0.4.10 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ security vulnerability detected
   │
   ├ ID: RUSTSEC-2025-0047
   ├ Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0047
   ├ ## Impact
     The `get_disjoint_mut` method in slab v0.4.10 incorrectly checked if indices were within the slab's capacity instead of its length, allowing access to uninitialized memory. This could lead to undefined behavior or potential crashes.

     ## Patches
     This has been fixed in slab v0.4.11.

     ## Workarounds
     Avoid using `get_disjoint_mut` with indices that might be beyond the slab's actual length, or upgrade to v0.4.11 or later.

     ## References
     * [https://github.com/tokio-rs/slab/pull/152](https://github.com/tokio-rs/slab/pull/152)
   ├ Announcement: https://github.com/tokio-rs/slab/security/advisories/GHSA-qx2v-8332-m4fv
   ├ Solution: Upgrade to >=0.4.11 (try `cargo update -p slab`)
   ├ slab v0.4.10
     └── tokio v1.46.1
         └── (dev) tmp108 v0.3.0

warning[yanked]: detected yanked crate (try `cargo update -p slab`)
   ┌─ /github/workspace/Cargo.lock:43:1
   │
43 │ slab 0.4.10 registry+https://github.com/rust-lang/crates.io-index
   │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ yanked version
   │
   ├ slab v0.4.10
     └── tokio v1.46.1
         └── (dev) tmp108 v0.3.0

advisories FAILED, bans ok, licenses ok, sources ok