### PR TITLE
feat!: reliability fixes (0.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,103 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is
+based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
+this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [0.6.0] — 2026-06-03
+
+A reliability-focused release. Several `Error` paths and `Tmp108`
+method signatures change in ways that are technically breaking but
+trivially mechanical to migrate; see the **Migration** section below.
+
+### Breaking
+
+- `Error` is now `Error<E, P = core::convert::Infallible>` and gains
+  a [`Pin(P)`] variant. The [`Other`] variant is removed.
+  - Bare `Tmp108<I2C>` continues to use `Error<I2C::Error>`; the
+    `Pin` variant is uninhabited (`P = Infallible`) and never
+    produced.
+  - `AlertTmp108<I2C, ALERT>` now uses
+    `Error<I2C::Error, ALERT::Error>` and surfaces GPIO failures via
+    `Error::Pin(_)` instead of silently mapping them to `Other`.
+- `Tmp108::set_low_limit` and `Tmp108::set_high_limit` now return
+  `Result<(), Error<I2C::Error>>` instead of `Result<(), I2C::Error>`.
+  They reject NaN, ±∞, and anything outside the chip's representable
+  range `[-128.0, 127.9375] °C` with `Error::InvalidInput`.
+  Previously these inputs were silently saturated via `as i16`.
+
+### Behavior changes (non-breaking signatures)
+
+- `Tmp108::continuous` now calls `shutdown()` on both the success and
+  error paths of the user closure. Previously a closure failure would
+  short-circuit cleanup and leave the chip in `Mode::Continuous`
+  indefinitely. The closure's error takes precedence over a shutdown
+  failure: the actionable signal wins. Callers that depended on the
+  chip remaining in Continuous mode after a closure failure must call
+  `configure(...)` explicitly.
+- `set_temperature_threshold_hysteresis` (on both `Tmp108` and
+  `AlertTmp108`) now snaps the input to the nearest legal value
+  within a 0.05 °C tolerance band instead of requiring exact equality
+  modulo `f32::EPSILON` (~1.2e-7). Inputs as ordinary as `0.1 + 0.9`
+  that previously failed will now succeed.
+- `to_celsius` no longer uses asymmetric integer division before the
+  float conversion. The new computation
+  (`f32::from(t) * (CELSIUS_PER_BIT / 16.0)`) produces identical
+  results for datasheet-conforming inputs (bits 3..0 == 0) and the
+  correct symmetric result for any non-zero low bits.
+
+### Added
+
+- `Tmp108::probe()` reads the configuration register and reports
+  whether it matches the documented power-on reset value (`0x1022`).
+  Useful immediately after power-on. Returns `Ok(true)` for POR
+  match, `Ok(false)` if the chip is present but already configured,
+  or `Err(_)` on bus failure.
+
+### Documentation
+
+- `Tmp108::continuous` is documented as **not cancel-safe**: dropping
+  the returned future (e.g. via `embassy_futures::select!` or
+  `tokio::time::timeout`) leaves the chip in `Mode::Continuous`
+  indefinitely.
+- `Tmp108::wait_for_temperature` is documented as "wait one
+  conversion period and then read." The first call after entering
+  `Mode::Continuous` may return the previous conversion. Each call
+  performs two I²C transactions; the doc explains how to avoid the
+  config-read overhead in bandwidth-sensitive loops.
+- `AlertTmp108`'s threshold-wait behavior is documented in detail:
+  Comparator-mode level-following (avoid tight loops; prefer
+  Interrupt mode), polarity-toggle race (do not reconfigure polarity
+  during a pending wait), and reliance on the `embedded-hal-async`
+  `Wait` trait contract for pending-edge handling.
+- Crate-level docs gain an "Operational notes" section covering the
+  single-master I²C bus assumption and the driver-drop lifecycle.
+
+### Migration
+
+For most downstream code the only required change is a single error
+pattern:
+
+```rust
+// Before
+match tmp.set_low_limit(value) {
+    Ok(()) => {}
+    Err(i2c_err) => /* handle */,
+}
+
+// After
+match tmp.set_low_limit(value) {
+    Ok(()) => {}
+    Err(Error::Bus(i2c_err)) => /* handle bus error */,
+    Err(Error::InvalidInput) => /* handle invalid f32 (new) */,
+}
+```
+
+Downstream code that pattern-matched on `Error::Other` should switch
+to `Error::Pin(_)` for the alert-pin case. Code that named
+`AlertTmp108`'s `Error` type explicitly should change
+`Error<I2C::Error>` to `Error<I2C::Error, ALERT::Error>`.
+
+## [0.5.0] and earlier
+
+See git history (`git log --oneline v0.5.0`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "tmp108"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_approx_eq",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmp108"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Felipe Balbi <febalbi@microsoft.com>"]
 repository = "https://github.com/OpenDevicePartnership/tmp108"
 license = "MIT"

--- a/docs/superpowers/specs/2026-06-03-tmp108-reliability-fixes-design.md
+++ b/docs/superpowers/specs/2026-06-03-tmp108-reliability-fixes-design.md
@@ -1,0 +1,479 @@
+# TMP108 Reliability Fixes — Design Spec
+
+**Status:** approved (interactive Q&A 2026-06-03)
+**Target release:** 0.6.0 (breaking)
+**Branch:** `reliability-fixes`
+**Companion plan:** `docs/superpowers/plans/2026-06-03-tmp108-reliability-fixes.md`
+
+---
+
+## Problem statement
+
+A reliability review of `tmp108` 0.5.0 surfaced a set of operational
+hazards in `src/lib.rs`. This document captures the agreed scope, the
+chosen fix for each item, and the resulting public-API impact. A
+companion architectural review proposed dropping `maybe-async-cfg` in
+favor of two named types (`Tmp108` / `AsyncTmp108`); **that work is
+explicitly deferred** to a follow-up release. This release does
+reliability fixes only, but is allowed to break API (and bump to 0.6.0)
+where doing so produces a more honest signature.
+
+## Goals
+
+1. Eliminate or document every behavior that can silently leave the
+   chip in an unsafe state in the field.
+2. Eliminate or document every behavior that loses caller-visible
+   error information.
+3. Land all of (1) and (2) in a single, bisectable PR with one commit
+   per fix.
+4. Bump to 0.6.0 with `BREAKING CHANGE:` footers where applicable.
+
+## Non-goals
+
+- Architectural restructuring (typestate, separate types, removing
+  `maybe-async-cfg`) — deferred.
+- Hardware verification of TLow/THigh resolution (H3) — requires lab
+  time and is orthogonal to the code changes.
+- Probe-on-construct (`new()` becoming fallible) — explicitly rejected
+  in review.
+- Diagnostic counters (L5) — out of scope.
+- I²C clock-stretching exposure (L4) — not a driver issue.
+
+---
+
+## Fix decisions (Critical → Medium)
+
+### C1. `continuous()` cancel-safety
+
+**Status:** doc-only.
+
+`Tmp108::continuous` writes `Mode::Continuous`, runs the user closure,
+then writes `Mode::Shutdown`. If the returned future is dropped (e.g.
+by `embassy_futures::select!`, `tokio::time::timeout`, or a task
+cancellation) the cleanup never runs and the chip is left burning
+current.
+
+A true RAII fix requires synchronous I²C inside an `async Drop`, which
+stable Rust does not support and which embedded HALs do not promise
+either. Solution: document loudly on the method, on the crate, and in
+`AGENTS.md` that **the returned future is not cancel-safe**. Callers
+must own the future to completion or arrange their own recovery.
+
+No new API. No signature change.
+
+### C2. `continuous()` error path
+
+**Status:** behavior change, non-breaking.
+
+Today: closure `Err` short-circuits via `?`, skipping `shutdown()`.
+
+After: closure result is captured, `shutdown()` runs unconditionally,
+**closure error wins** over shutdown error (matches user intent — the
+caller's failure is the actionable signal; shutdown failure is a
+secondary cleanup symptom).
+
+```rust
+let user = f(self).await;
+let cleanup = self.shutdown().await;
+user.and(cleanup)   // Ok only if both succeeded; closure error preferred over shutdown error
+```
+
+`.and` returns the first `Err`, or the second `Ok` — correct for "user
+error wins, cleanup error reported if user succeeded."
+
+No signature change. Behavior change is observable (callers that
+relied on chip being in Continuous after a closure failure will
+notice). Documented in CHANGELOG.
+
+### C3. Range validation on `set_low_limit` / `set_high_limit`
+
+**Status:** breaking — return type changes.
+
+Today: `pub async fn set_low_limit(&mut self, limit: f32) -> Result<(), I2C::Error>`
+silently saturates inputs outside `[-128.0, 127.9375]` via `as i16`.
+
+After: reject NaN, ±Inf, and anything outside `[-128.0, 127.9375]`
+with `Error::InvalidInput`.
+
+Signature changes to:
+
+```rust
+pub async fn set_low_limit(&mut self, limit: f32) -> Result<(), Error<I2C::Error>>
+pub async fn set_high_limit(&mut self, limit: f32) -> Result<(), Error<I2C::Error>>
+```
+
+**BREAKING:** the success path is unchanged but the error type is
+now `Error<I2C::Error>` not `I2C::Error`. Callers that pattern-match
+on `I2C::Error` directly need to extract via `Error::Bus(e) => ...`.
+
+The validation range `[-128.0, 127.9375]` is the full representable
+range of the 12-bit fixed-point register, not the TMP108's
+operating-temperature window (−55…+127 °C). The wider range is
+chosen because the chip itself accepts these values; the operating
+window is a board-design concern, not a driver invariant.
+
+### H1. AlertTmp108 Interrupt-mode lost edges
+
+**Status:** rejected as a "fix"; documented as a contract.
+
+The reliability review proposed sampling `InputPin::is_low`/`is_high`
+on entry. User clarification: **the `Wait` trait already handles
+pending edges via the MCU's GPIO controller** — that's the contract
+of `embedded_hal_async::digital::Wait`. Implementations that drop
+pending edges between calls are non-conforming; that is the HAL
+implementor's responsibility, not the driver's.
+
+Action: add a brief doc note on `wait_for_temperature_threshold`
+referencing the `Wait` contract. No code change.
+
+### H2. AlertTmp108 Comparator-mode busy-loop
+
+**Status:** documented.
+
+`wait_for_low`/`wait_for_high` return immediately when the line is
+already at the requested level. In Comparator mode the ALERT pin
+stays asserted until the temperature returns to the hysteresis band.
+Callers writing a `loop { wait...; }` pattern will spin.
+
+Action: document on the method that Comparator-mode callers should
+either (a) use Interrupt mode for level-following semantics, or (b)
+apply application-level backoff between iterations. No code change
+(the `Wait` trait does not expose a "wait for deassertion" primitive
+that would let us do this cleanly without an opinionated semantic
+change).
+
+### H3. TLow/THigh resolution verification
+
+**Status:** out of scope.
+
+Hardware-only verification. Tracked as a TODO comment in the
+hardware-verification matrix.
+
+### H4. Stale-first-reading in `wait_for_temperature`
+
+**Status:** documented.
+
+The delay table is the conversion *period* (1/CR), not the conversion
+*time*. First call after entering Continuous can return a stale
+value. Documentation on the method explains the semantics: "wait one
+period and then read; the first read after entering Continuous may
+return the previous conversion. For 'guaranteed fresh,' use
+`one_shot()` + period delay + `temperature()`."
+
+No code change.
+
+### H5. `Hysteresis` snapping
+
+**Status:** behavior change, non-breaking.
+
+Today: `(hysteresis - 1.0).abs() < f32::EPSILON` is too strict
+(1.2e-7 tolerance). `0.1 + 0.9` fails.
+
+After: snap to nearest of `{0, 1, 2, 4}` within a 0.05 °C tolerance
+band; beyond tolerance return `Error::InvalidInput`.
+
+```rust
+// Pseudo-code; final form in the implementation step.
+const HYS_VALUES: [(f32, Hysteresis); 4] = [
+    (0.0, Hysteresis::_0C),
+    (1.0, Hysteresis::_1C),
+    (2.0, Hysteresis::_2C),
+    (4.0, Hysteresis::_4C),
+];
+let (legal, h) = HYS_VALUES
+    .iter()
+    .copied()
+    .min_by(|(a, _), (b, _)| (hysteresis - a).abs().total_cmp(&(hysteresis - b).abs()))
+    .unwrap();
+if (hysteresis - legal).abs() > 0.05 {
+    return Err(Error::InvalidInput);
+}
+```
+
+(NaN handling: `total_cmp` orders NaN to one end; will likely fall
+outside any 0.05 tolerance and reject. Explicit NaN check added to
+be safe.)
+
+Same signature, same return type — callers that previously rejected
+`0.1 + 0.9` will now accept it. Non-breaking improvement.
+
+### H6. `Error::Other` swallows GPIO error
+
+**Status:** breaking — `Error` gains a type parameter.
+
+Today:
+
+```rust
+pub enum Error<E: embedded_hal::i2c::Error> {
+    Bus(E),
+    InvalidInput,
+    Other,
+}
+```
+
+After:
+
+```rust
+pub enum Error<E: embedded_hal::i2c::Error, P: embedded_hal::digital::Error = core::convert::Infallible> {
+    Bus(E),
+    InvalidInput,
+    Pin(P),
+}
+```
+
+(`Other` is removed — every existing producer of `Error::Other` is
+either a GPIO error that now uses `Error::Pin(...)` or a now-corrected
+swallowed `Bus(...)`.)
+
+`AlertTmp108<I2C, ALERT>` produces `Error<I2C::Error, ALERT::Error>`.
+Bare `Tmp108<I2C>` continues to use the default `P =
+core::convert::Infallible` (it never reports a Pin error).
+
+**BREAKING:**
+
+- The `P` type parameter is new. Pattern matches against `Error::Other`
+  must be replaced (recommended migration: pattern on `Error::Pin(e)`
+  for GPIO failures, keep `Bus`/`InvalidInput` matches as-is).
+- The `Default` for `P` keeps `Error<I2C::Error>` working at most
+  bare-`Tmp108` call sites.
+
+### M1. RMW atomicity on multi-master
+
+**Status:** documented.
+
+Add a "Concurrency" section to the crate-level doc explaining the
+single-master assumption.
+
+### M2. `probe()` method
+
+**Status:** new non-breaking method.
+
+```rust
+/// Probe the bus by reading the configuration register and confirming the
+/// POR value (`0x1022`). Useful immediately after power-on. False negatives
+/// possible if the chip was already reconfigured.
+pub async fn probe(&mut self) -> Result<(), I2C::Error>
+```
+
+Returns `Ok(())` if the read succeeds and matches POR. Returns the
+`I2C::Error` if the read fails. Returns `Ok(())` *only* if it matches
+POR — if the read succeeds but the value differs (chip was already
+configured), returns `Ok(())` as well? **No** — we surface this as a
+separate signal: the method is honest about "did I see POR?" by
+returning `Ok(true)` for POR match, `Ok(false)` for read-succeeded-
+but-not-POR, and `Err(...)` for read failure.
+
+Final shape:
+
+```rust
+pub async fn probe(&mut self) -> Result<bool, I2C::Error>
+```
+
+Documentation: "Returns `Ok(true)` if the configuration register reads
+the documented POR value `0x1022` (chip is freshly powered up and
+present), `Ok(false)` if the read succeeded but the chip was already
+configured to a different state (still strong evidence the chip is
+present), `Err(...)` if the read failed (chip likely missing or
+unreachable)."
+
+### M3. `Drop` lifecycle clarity
+
+**Status:** documented.
+
+Add a `# Lifecycle` section to the `Tmp108` doc comment explaining
+that dropping the driver does not change the chip state, and that
+callers should `shutdown()` explicitly before dropping if they want
+the chip to stop consuming idle current.
+
+### M4. Polarity-toggle race
+
+**Status:** documented.
+
+Doc note on `wait_for_temperature_threshold` that polarity must not
+be changed concurrently with a pending call.
+
+### M5. `to_celsius` integer division
+
+**Status:** code change, non-breaking.
+
+Replace:
+
+```rust
+fn to_celsius(t: i16) -> f32 {
+    f32::from(t / 16) * Self::CELSIUS_PER_BIT
+}
+```
+
+with:
+
+```rust
+fn to_celsius(t: i16) -> f32 {
+    f32::from(t) * (Self::CELSIUS_PER_BIT / 16.0)
+}
+```
+
+`CELSIUS_PER_BIT / 16.0 = 0.00390625`, exactly representable. Same
+results on legal datasheet-conforming inputs (low 4 bits = 0).
+Asymmetric for negative inputs with non-zero low bits — fixed.
+Existing unit tests at `src/lib.rs:1300-1421` (blocking) and
+`src/lib.rs:1497-1618` (async) cover the change.
+
+### M6. Per-sample config read in `wait_for_temperature`
+
+**Status:** documented.
+
+Doc note on `wait_for_temperature` that each call performs an extra
+I²C round trip to read the configuration register. Callers that
+need to minimize bus traffic should call `read_configuration()`
+once and implement the period delay themselves.
+
+---
+
+## Public-API impact summary
+
+### Breaking changes
+
+| Symbol | Before | After |
+|---|---|---|
+| `Error<E>` | `Error<E: embedded_hal::i2c::Error>` | `Error<E, P = core::convert::Infallible>` |
+| `Error::Other` | variant exists | removed |
+| `Tmp108::set_low_limit` | `-> Result<(), I2C::Error>` | `-> Result<(), Error<I2C::Error>>` |
+| `Tmp108::set_high_limit` | `-> Result<(), I2C::Error>` | `-> Result<(), Error<I2C::Error>>` |
+| `AlertTmp108` trait `Error` | `Error<I2C::Error>` (with `P = Infallible` impossible because pin error was mapped to `Other`) | `Error<I2C::Error, ALERT::Error>` |
+
+### Non-breaking additions
+
+| Symbol | Purpose |
+|---|---|
+| `Tmp108::probe` | confirm chip presence + POR |
+| `Error::Pin(P)` variant | preserve GPIO error |
+
+### Behavior changes (same signature)
+
+| Method | Change |
+|---|---|
+| `Tmp108::continuous` | shutdown now runs on closure `Err`; closure error wins |
+| `set_temperature_threshold_hysteresis` | tolerance widened from `f32::EPSILON` to 0.05 °C, snap to nearest |
+| internal `to_celsius` | integer division removed |
+
+### Documentation-only changes
+
+- `continuous()` — cancel-safety contract
+- `wait_for_temperature_threshold` — `Wait` contract reference, polarity race note
+- `wait_for_temperature` — stale-first-reading note, per-call I²C cost note
+- crate-level — single-master assumption, lifecycle (drop) note
+
+---
+
+## Migration notes (for CHANGELOG.md)
+
+```
+## 0.6.0
+
+### Breaking
+
+- `Error` is now `Error<E, P = core::convert::Infallible>` and gains a
+  `Pin(P)` variant. The `Other` variant is removed. `AlertTmp108`
+  errors now carry the underlying GPIO error in `Pin(P)`; previously
+  they were silently mapped to `Other`.
+- `Tmp108::set_low_limit` and `set_high_limit` now return
+  `Result<(), Error<I2C::Error>>` and reject NaN / ±Inf / out-of-range
+  inputs with `Error::InvalidInput`. Previously they silently saturated.
+- `Tmp108::continuous` now calls `shutdown()` on both the success and
+  error paths of the user closure. Callers that depended on the chip
+  remaining in Continuous mode after a closure failure must call
+  `configure(...)` explicitly.
+
+### Added
+
+- `Tmp108::probe()` confirms chip presence and reports whether the
+  configuration register matches the documented POR value.
+
+### Fixed
+
+- `set_temperature_threshold_hysteresis` no longer rejects float
+  arithmetic that lands within 0.05 °C of a legal value
+  (previously the tolerance was `f32::EPSILON`).
+- `to_celsius` no longer uses asymmetric integer division before the
+  float conversion.
+
+### Documented
+
+- `continuous()` future is not cancel-safe.
+- `wait_for_temperature_threshold` polarity must not change concurrently.
+- `wait_for_temperature` may return stale data on the first call after
+  entering Continuous mode.
+- The driver assumes single-master I²C bus ownership.
+- Dropping the driver does not change the chip's operating mode.
+```
+
+---
+
+## Commit plan (bisectable, one concern per commit)
+
+Order chosen so each commit is independently buildable and tests at
+its level of coverage pass. Per AGENTS.md Gotcha 6 ("each commit
+builds clean without warning") each commit contains both the new
+tests and the implementation that satisfies them — TDD is preserved
+in the workflow (write test, watch it fail, implement) but the
+failing-test state is never committed.
+
+1. `feat!: validate set_*_limit inputs, return Error::InvalidInput` (C3) **BREAKING**
+2. `fix: run shutdown() in continuous() on both success and error paths` (C2)
+3. `fix: snap hysteresis input to nearest legal value within 0.05C` (H5)
+4. `refactor: remove integer division from to_celsius` (M5)
+5. `feat!: replace Error::Other with Error::Pin generic over ALERT::Error` (H6) **BREAKING**
+6. `feat: add Tmp108::probe() method` (M2)
+7. `docs: cancel-safety, lifecycle, concurrency, stale-read warnings` (C1, H1, H2, H4, M1, M3, M4, M6)
+8. `chore: bump version to 0.6.0 and add CHANGELOG`
+
+Each commit:
+- Builds clean under all four feature combinations (`cargo hack`).
+- Passes `cargo clippy --all-features --all-targets` with the
+  pedantic config.
+- Passes `cargo +nightly fmt --check`.
+- Passes `cargo test` at its applicable feature levels.
+- Has the `Assisted-by:` trailer per AGENTS.md.
+
+The version bump and CHANGELOG are intentionally last so that
+`cargo semver-checks` flags each breaking commit individually during
+bisect.
+
+---
+
+## Out of scope for this PR (tracked for follow-up)
+
+- Architectural refactor to two named types `Tmp108` / `AsyncTmp108`
+  (architect's recommendation; will be a separate plan after this PR
+  is integrated).
+- Hardware verification of TLow/THigh resolution (H3).
+- Diagnostic counters (L5).
+- `Eq` on `Config` (low-priority cleanup, can wait for the
+  architectural PR).
+- Making `AlertTmp108::tmp108` private + adding `into_inner()` (will
+  be addressed by the named-types refactor anyway).
+- `Clone`/`PartialEq` on `Error` (depends on `E: Clone + PartialEq`
+  which is uncommon; skip).
+
+---
+
+## Risks
+
+1. **The H6 breaking change has wide blast radius.** Every match on
+   `Error::Other` in downstream code breaks. The `Pin` variant is a
+   real semantic improvement but the migration is mechanical. CHANGELOG
+   covers it.
+2. **Adding a generic parameter with a default to a public enum** is
+   *binary* breaking (size/layout can shift) but *source* compatible
+   for typical use because of `P = Infallible`. `cargo semver-checks`
+   will flag it as major; the explicit 0.6.0 bump is the right answer.
+3. **The C2 behavior change (shutdown on error) may surprise** users
+   who deliberately wanted to inspect the chip after a closure failure.
+   The CHANGELOG is explicit; the new behavior matches the safer
+   default and matches what most callers expect.
+4. **Per-commit clippy/test stability.** TDD is followed in the
+   working tree (write the test, watch it fail, implement) but the
+   failing-test state is never committed; each commit lands test +
+   implementation together. This satisfies AGENTS.md Gotcha 6 ("each
+   commit builds clean without warning") while preserving the
+   discipline.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1169,24 +1169,40 @@ impl<I2C: embedded_hal_async::i2c::I2c> embedded_sensors_hal_async::temperature:
         &mut self,
         hysteresis: embedded_sensors_hal_async::temperature::DegreesCelsius,
     ) -> Result<(), Self::Error> {
-        // Trait method takes a continuous range of f32 values as argument, but internally driver
-        // only accepts 4 discrete values for hysteresis.
+        // The trait method takes a continuous range of f32 °C values, but
+        // the chip only supports four discrete hysteresis settings:
+        // 0, 1, 2, and 4 °C. Snap the input to the nearest legal value
+        // within a tolerance band of 0.05 °C; reject anything outside the
+        // band (and any non-finite input) with `Error::InvalidInput`.
         //
-        // We ensure only a correct value for hysteresis is passed in, and return error otherwise.
-        let hysteresis = if (hysteresis - 0.0).abs() < f32::EPSILON {
-            Hysteresis::_0C
-        } else if (hysteresis - 1.0).abs() < f32::EPSILON {
-            Hysteresis::_1C
-        } else if (hysteresis - 2.0).abs() < f32::EPSILON {
-            Hysteresis::_2C
-        } else if (hysteresis - 4.0).abs() < f32::EPSILON {
-            Hysteresis::_4C
-        } else {
+        // The tolerance is generous enough to absorb ordinary float
+        // arithmetic (e.g. 0.1 + 0.9 rounding away from 1.0) while still
+        // surfacing genuinely unsupported requests like 3.0 °C.
+        const HYS_VALUES: &[(f32, Hysteresis)] = &[
+            (0.0, Hysteresis::_0C),
+            (1.0, Hysteresis::_1C),
+            (2.0, Hysteresis::_2C),
+            (4.0, Hysteresis::_4C),
+        ];
+        const HYS_TOLERANCE: f32 = 0.05;
+
+        if !hysteresis.is_finite() {
             return Err(Error::InvalidInput);
-        };
+        }
+
+        // HYS_VALUES is non-empty so min_by always returns Some.
+        let (closest, snapped) = HYS_VALUES
+            .iter()
+            .copied()
+            .min_by(|(a, _), (b, _)| (hysteresis - a).abs().total_cmp(&(hysteresis - b).abs()))
+            .expect("HYS_VALUES is non-empty");
+
+        if (hysteresis - closest).abs() > HYS_TOLERANCE {
+            return Err(Error::InvalidInput);
+        }
 
         let mut config = self.read_configuration().await.map_err(|_| Error::Other)?;
-        config.hysteresis = hysteresis;
+        config.hysteresis = snapped;
         self.configure(config).await.map_err(Error::Bus)
     }
 }
@@ -1845,6 +1861,95 @@ mod tests {
             let (mut i2c_mock, mut pin_mock) = tmp108.destroy();
             i2c_mock.done();
             pin_mock.done();
+        }
+
+        #[cfg(feature = "embedded-sensors-hal-async")]
+        #[tokio::test]
+        async fn hysteresis_snaps_within_tolerance() {
+            use embedded_sensors_hal_async::temperature::TemperatureHysteresis;
+
+            // For each legal value, every input within 0.05 °C must
+            // succeed and program the corresponding chip setting (no I2C
+            // mismatch). Each acceptance path performs: read cfg, write cfg.
+            //
+            // - 0.0 °C snaps to Hysteresis::_0C => HYS bits 0b00 => cfg word 0x0022 -> bytes [0x22, 0x00]
+            // - 1.0 °C snaps to Hysteresis::_1C => HYS bits 0b01 => cfg word 0x1022 -> bytes [0x22, 0x10]
+            // - 2.0 °C snaps to Hysteresis::_2C => HYS bits 0b10 => cfg word 0x2022 -> bytes [0x22, 0x20]
+            // - 4.0 °C snaps to Hysteresis::_4C => HYS bits 0b11 => cfg word 0x3022 -> bytes [0x22, 0x30]
+            //
+            // For each accepted input we expect: write-read of cfg, then a
+            // write of the new cfg. The chip's POR is 0x1022 (HYS=01).
+            let cases: &[(f32, [u8; 2])] = &[
+                // Exact-match accepted values.
+                (0.0, [0x22, 0x00]),
+                (1.0, [0x22, 0x10]),
+                (2.0, [0x22, 0x20]),
+                (4.0, [0x22, 0x30]),
+                // Within-tolerance inputs that previously failed under
+                // f32::EPSILON snapping.
+                (0.04_f32, [0x22, 0x00]),
+                (1.000_000_1_f32, [0x22, 0x10]),
+                (0.1_f32 + 0.9_f32, [0x22, 0x10]),
+                (1.95_f32, [0x22, 0x20]),
+                (3.97_f32, [0x22, 0x30]),
+            ];
+
+            // Each accepted input triggers:
+            //   1. read_configuration() in the hysteresis impl: write_read
+            //   2. configure() -> modify (read-modify-write): write_read + write
+            // The current cfg byte stream is the chip's POR value 0x1022 ->
+            // [0x22, 0x10]. After snapping the result is reflected in the
+            // HYS bits of the final write.
+            let mut expectations = Vec::new();
+            for (_, written) in cases {
+                // read_configuration
+                expectations.push(Transaction::write_read(0x48, vec![0x01], vec![0x22, 0x10]));
+                // configure -> modify: read
+                expectations.push(Transaction::write_read(0x48, vec![0x01], vec![0x22, 0x10]));
+                // configure -> modify: write
+                expectations.push(Transaction::write(0x48, vec![0x01, written[0], written[1]]));
+            }
+
+            let mock = Mock::new(&expectations);
+            let mut tmp108 = Tmp108::new_with_a0_gnd(mock);
+
+            for (input, _) in cases {
+                let r = tmp108.set_temperature_threshold_hysteresis(*input).await;
+                assert!(r.is_ok(), "input {input} should be accepted");
+            }
+
+            let mut mock = tmp108.destroy();
+            mock.done();
+        }
+
+        #[cfg(feature = "embedded-sensors-hal-async")]
+        #[tokio::test]
+        async fn hysteresis_rejects_out_of_tolerance_and_non_finite() {
+            use embedded_sensors_hal_async::temperature::TemperatureHysteresis;
+
+            // No I2C transactions expected; out-of-tolerance and non-finite
+            // inputs must be rejected before any bus traffic.
+            let mock = Mock::new(&[]);
+            let mut tmp108 = Tmp108::new_with_a0_gnd(mock);
+
+            for bad in [-0.5_f32, 0.5_f32, 3.0_f32, 5.0_f32, -1.0_f32, 10.0_f32] {
+                let r = tmp108.set_temperature_threshold_hysteresis(bad).await;
+                assert!(
+                    matches!(r, Err(Error::InvalidInput)),
+                    "input {bad} should be rejected as InvalidInput, got {r:?}"
+                );
+            }
+
+            for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+                let r = tmp108.set_temperature_threshold_hysteresis(bad).await;
+                assert!(
+                    matches!(r, Err(Error::InvalidInput)),
+                    "input {bad} should be rejected as InvalidInput, got {r:?}"
+                );
+            }
+
+            let mut mock = tmp108.destroy();
+            mock.done();
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -774,7 +774,10 @@ impl<I2C: AsyncI2c> Tmp108<I2C> {
     ///
     /// # Errors
     ///
-    /// `I2C::Error` when the I2C transaction fails
+    /// - `Error::InvalidInput` if `limit` is NaN, ±∞, or outside
+    ///   `[-128.0, 127.9375] °C` (the representable range of the chip's
+    ///   12-bit fixed-point limit register).
+    /// - `Error::Bus` when the I2C transaction fails.
     ///
     /// (Doctest runs against the blocking API; the async variant has the same
     /// shape with `.await` after the call.)
@@ -796,14 +799,18 @@ impl<I2C: AsyncI2c> Tmp108<I2C> {
     /// # i2c.done();
     /// # }
     /// ```
-    pub async fn set_low_limit(&mut self, limit: f32) -> Result<(), I2C::Error> {
-        let raw = Self::to_raw(limit).to_be_bytes();
+    pub async fn set_low_limit(&mut self, limit: f32) -> Result<(), Error<I2C::Error>> {
+        let raw = Self::to_raw(limit).ok_or(Error::InvalidInput)?.to_be_bytes();
 
         #[cfg(feature = "async")]
-        self.inner.t_low().write_async(|r| *r = TLow::from(raw)).await?;
+        self.inner
+            .t_low()
+            .write_async(|r| *r = TLow::from(raw))
+            .await
+            .map_err(Error::Bus)?;
 
         #[cfg(not(feature = "async"))]
-        self.inner.t_low().write(|r| *r = TLow::from(raw))?;
+        self.inner.t_low().write(|r| *r = TLow::from(raw)).map_err(Error::Bus)?;
 
         Ok(())
     }
@@ -848,7 +855,10 @@ impl<I2C: AsyncI2c> Tmp108<I2C> {
     ///
     /// # Errors
     ///
-    /// `I2C::Error` when the I2C transaction fails
+    /// - `Error::InvalidInput` if `limit` is NaN, ±∞, or outside
+    ///   `[-128.0, 127.9375] °C` (the representable range of the chip's
+    ///   12-bit fixed-point limit register).
+    /// - `Error::Bus` when the I2C transaction fails.
     ///
     /// (Doctest runs against the blocking API; the async variant has the same
     /// shape with `.await` after the call.)
@@ -870,14 +880,21 @@ impl<I2C: AsyncI2c> Tmp108<I2C> {
     /// # i2c.done();
     /// # }
     /// ```
-    pub async fn set_high_limit(&mut self, limit: f32) -> Result<(), I2C::Error> {
-        let raw = Self::to_raw(limit).to_be_bytes();
+    pub async fn set_high_limit(&mut self, limit: f32) -> Result<(), Error<I2C::Error>> {
+        let raw = Self::to_raw(limit).ok_or(Error::InvalidInput)?.to_be_bytes();
 
         #[cfg(feature = "async")]
-        self.inner.t_high().write_async(|r| *r = THigh::from(raw)).await?;
+        self.inner
+            .t_high()
+            .write_async(|r| *r = THigh::from(raw))
+            .await
+            .map_err(Error::Bus)?;
 
         #[cfg(not(feature = "async"))]
-        self.inner.t_high().write(|r| *r = THigh::from(raw))?;
+        self.inner
+            .t_high()
+            .write(|r| *r = THigh::from(raw))
+            .map_err(Error::Bus)?;
 
         Ok(())
     }
@@ -886,9 +903,23 @@ impl<I2C: AsyncI2c> Tmp108<I2C> {
         f32::from(t / 16) * Self::CELSIUS_PER_BIT
     }
 
-    #[allow(clippy::cast_possible_truncation)]
-    fn to_raw(t: f32) -> i16 {
-        (t * 16.0 / Self::CELSIUS_PER_BIT) as i16
+    /// Convert a temperature in degrees Celsius to the raw 12-bit signed
+    /// fixed-point representation used by the chip's TLow/THigh registers.
+    ///
+    /// Returns `None` for inputs that are NaN, ±∞, or outside the
+    /// representable range `[-128.0, 127.9375] °C`.
+    fn to_raw(t: f32) -> Option<i16> {
+        // i16 representable range divided by the 16x scale factor.
+        const MIN: f32 = -128.0;
+        const MAX: f32 = 127.937_5;
+
+        if !t.is_finite() || !(MIN..=MAX).contains(&t) {
+            return None;
+        }
+
+        // Range-checked above; this cast cannot truncate.
+        #[allow(clippy::cast_possible_truncation)]
+        Some((t * 16.0 / Self::CELSIUS_PER_BIT) as i16)
     }
 }
 
@@ -1029,14 +1060,14 @@ impl<I2C: embedded_hal_async::i2c::I2c> embedded_sensors_hal_async::temperature:
         &mut self,
         threshold: embedded_sensors_hal_async::temperature::DegreesCelsius,
     ) -> Result<(), Self::Error> {
-        self.set_low_limit(threshold).await.map_err(Error::Bus)
+        self.set_low_limit(threshold).await
     }
 
     async fn set_temperature_threshold_high(
         &mut self,
         threshold: embedded_sensors_hal_async::temperature::DegreesCelsius,
     ) -> Result<(), Self::Error> {
-        self.set_high_limit(threshold).await.map_err(Error::Bus)
+        self.set_high_limit(threshold).await
     }
 }
 
@@ -1048,14 +1079,14 @@ impl<I2C: embedded_hal_async::i2c::I2c, ALERT: embedded_hal_async::digital::Wait
         &mut self,
         threshold: embedded_sensors_hal_async::temperature::DegreesCelsius,
     ) -> Result<(), Self::Error> {
-        self.tmp108.set_low_limit(threshold).await.map_err(Error::Bus)
+        self.tmp108.set_low_limit(threshold).await
     }
 
     async fn set_temperature_threshold_high(
         &mut self,
         threshold: embedded_sensors_hal_async::temperature::DegreesCelsius,
     ) -> Result<(), Self::Error> {
-        self.tmp108.set_high_limit(threshold).await.map_err(Error::Bus)
+        self.tmp108.set_high_limit(threshold).await
     }
 }
 
@@ -1419,6 +1450,29 @@ mod tests {
             let mut mock = tmp108.destroy();
             mock.done();
         }
+
+        #[test]
+        fn reject_invalid_set_limit_inputs() {
+            // No I2C transactions are expected; out-of-range / non-finite
+            // inputs must be rejected before any bus traffic.
+            let mock = Mock::new(&[]);
+            let mut tmp108 = Tmp108::new_with_a0_gnd(mock);
+
+            // Values just outside the representable [-128.0, 127.9375] range.
+            for bad in [128.0_f32, 127.940_f32, -128.001_f32, -200.0_f32, 200.0_f32] {
+                assert!(matches!(tmp108.set_low_limit(bad), Err(Error::InvalidInput)));
+                assert!(matches!(tmp108.set_high_limit(bad), Err(Error::InvalidInput)));
+            }
+
+            // Non-finite values.
+            for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+                assert!(matches!(tmp108.set_low_limit(bad), Err(Error::InvalidInput)));
+                assert!(matches!(tmp108.set_high_limit(bad), Err(Error::InvalidInput)));
+            }
+
+            let mut mock = tmp108.destroy();
+            mock.done();
+        }
     }
 
     #[cfg(feature = "async")]
@@ -1611,6 +1665,29 @@ mod tests {
 
                 let temp = result.unwrap();
                 assert_approx_eq!(temp, *t, 1e-4);
+            }
+
+            let mut mock = tmp108.destroy();
+            mock.done();
+        }
+
+        #[tokio::test]
+        async fn reject_invalid_set_limit_inputs() {
+            // No I2C transactions are expected; out-of-range / non-finite
+            // inputs must be rejected before any bus traffic.
+            let mock = Mock::new(&[]);
+            let mut tmp108 = Tmp108::new_with_a0_gnd(mock);
+
+            // Values just outside the representable [-128.0, 127.9375] range.
+            for bad in [128.0_f32, 127.940_f32, -128.001_f32, -200.0_f32, 200.0_f32] {
+                assert!(matches!(tmp108.set_low_limit(bad).await, Err(Error::InvalidInput)));
+                assert!(matches!(tmp108.set_high_limit(bad).await, Err(Error::InvalidInput)));
+            }
+
+            // Non-finite values.
+            for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+                assert!(matches!(tmp108.set_low_limit(bad).await, Err(Error::InvalidInput)));
+                assert!(matches!(tmp108.set_high_limit(bad).await, Err(Error::InvalidInput)));
             }
 
             let mut mock = tmp108.destroy();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,33 @@
 //! to the official [`Datasheet`].
 //!
 //! [`Datasheet`]: https://www.ti.com/lit/gpn/tmp108
+//!
+//! # Operational notes
+//!
+//! ## I²C bus ownership
+//!
+//! The driver assumes single-master ownership of the TMP108. Several
+//! methods (notably [`Tmp108::configure`], [`Tmp108::one_shot`], and
+//! [`Tmp108::shutdown`]) perform a read-modify-write on the
+//! configuration register as two distinct I²C transactions. On a
+//! multi-master bus, a second master writing to register `0x01`
+//! between the read and the write will silently lose those writes —
+//! the TMP108 has no register-level lock. In multi-master designs,
+//! serialise driver access at a higher level (e.g. a bus mutex around
+//! the entire driver, not just individual I²C transactions).
+//!
+//! ## Driver lifecycle on drop
+//!
+//! Dropping a [`Tmp108`] or [`AlertTmp108`] does **not** change the
+//! chip's operating mode. The chip retains whatever `M` bits were last
+//! written. If you want the chip to stop drawing current after the
+//! driver goes out of scope, call [`Tmp108::shutdown`] (or finish a
+//! [`Tmp108::continuous`] call cleanly) before dropping.
+//!
+//! In particular, dropping the future returned by
+//! [`Tmp108::continuous`] mid-flight (e.g. via `embassy_futures::select!`
+//! or `tokio::time::timeout`) leaves the chip in `Mode::Continuous`
+//! indefinitely. See the cancel-safety note on that method.
 
 #![doc(html_root_url = "https://docs.rs/tmp108/latest")]
 #![doc = include_str!("../README.md")]
@@ -261,7 +288,42 @@ impl<I2C: AsyncI2c> Tmp108<I2C> {
     }
 }
 
-/// Tmp108 asynchronous device driver (with alert pin)
+/// Async TMP108 driver with an ALERT GPIO pin attached.
+///
+/// Wraps a bare [`Tmp108`] with a pin implementing
+/// [`embedded_hal_async::digital::Wait`] (and
+/// [`embedded_hal::digital::InputPin`]), so it can implement
+/// [`embedded_sensors_hal_async::temperature::TemperatureThresholdWait`].
+///
+/// # Notes on alert behavior
+///
+/// The driver's [`wait_for_temperature_threshold`][1] implementation
+/// relies on the `embedded-hal-async` [`Wait`][2] trait contract:
+/// implementations must report transitions that occur between `Wait`
+/// calls (e.g. via a pending-edge / latched-interrupt mechanism in the
+/// MCU's GPIO controller). If the HAL implementation drops pending
+/// edges, the driver will miss them — this is a property of the HAL,
+/// not the driver.
+///
+/// The chip's `Polarity` (active-low vs active-high) is read from the
+/// configuration register on every call to `wait_for_temperature_threshold`.
+/// Do **not** reconfigure polarity while a `wait_for_temperature_threshold`
+/// future is pending — the awaiting future will continue to wait for the
+/// old polarity while the chip's ALERT output follows the new one.
+///
+/// In Comparator mode the ALERT pin remains asserted as long as the
+/// temperature is outside the `[TLow + HYS, THigh − HYS]` band; calling
+/// `wait_for_temperature_threshold` in a tight loop while the chip is
+/// still over-temperature will return immediately on every iteration
+/// (because [`wait_for_low`][3] / [`wait_for_high`][4] return
+/// immediately when the pin is already at the requested level). For
+/// repeated-trigger workflows prefer Interrupt mode, or apply
+/// application-level backoff between iterations.
+///
+/// [1]: embedded_sensors_hal_async::temperature::TemperatureThresholdWait::wait_for_temperature_threshold
+/// [2]: embedded_hal_async::digital::Wait
+/// [3]: embedded_hal_async::digital::Wait::wait_for_low
+/// [4]: embedded_hal_async::digital::Wait::wait_for_high
 #[cfg(all(feature = "embedded-sensors-hal-async", feature = "async"))]
 pub struct AlertTmp108<
     I2C: embedded_hal_async::i2c::I2c,
@@ -777,14 +839,41 @@ impl<I2C: AsyncI2c> Tmp108<I2C> {
         user_result.and(cleanup_result)
     }
 
-    /// Wait for conversion to complete. This method will block for the amount
-    /// of time dictated by the CR bits in the `Configuration` register.
-    /// Caller is required to call this method from within their continuous
-    /// conversion closure.
+    /// Wait one conversion period, then read the temperature register.
+    ///
+    /// Reads the configuration register to discover the current
+    /// [`ConversionRate`], delays for one period (1/CR), and then reads
+    /// the temperature register. Intended for callers driving the chip
+    /// in [`Mode::Continuous`] (typically from inside a
+    /// [`continuous`][Self::continuous] closure) who want to align
+    /// reads with the chip's conversion cadence.
+    ///
+    /// # Stale-reading on first call
+    ///
+    /// The TMP108's conversion period (1/CR — 4 s, 1 s, 250 ms, or
+    /// 62.5 ms) is **not** the same as its conversion **time** (~30 ms
+    /// regardless of CR). After entering [`Mode::Continuous`] the chip's
+    /// next conversion is not phase-aligned with when you enabled it,
+    /// so the first call to this method may return the previous
+    /// conversion result. For "guaranteed fresh" semantics, use
+    /// [`one_shot`][Self::one_shot] followed by a delay of one period
+    /// and a [`temperature`][Self::temperature] read, or discard the
+    /// first reading after entering Continuous.
+    ///
+    /// # I²C cost per call
+    ///
+    /// Each call performs **two** I²C transactions: a configuration
+    /// read (to determine the CR) and a temperature read. Callers in
+    /// power- or bandwidth-sensitive loops who know they will not
+    /// change CR can avoid the per-call configuration read by calling
+    /// [`read_configuration`][Self::read_configuration] once, computing
+    /// the period delay themselves, and calling
+    /// [`temperature`][Self::temperature] directly.
     ///
     /// # Errors
     ///
-    /// `I2C::Error` when the I2C transaction fails
+    /// `I2C::Error` when either the configuration read or the
+    /// temperature read fails.
     ///
     /// (Doctest runs against the blocking API; the async variant has the same
     /// shape with `.await` after the calls.)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -928,7 +928,19 @@ impl<I2C: AsyncI2c> Tmp108<I2C> {
     }
 
     fn to_celsius(t: i16) -> f32 {
-        f32::from(t / 16) * Self::CELSIUS_PER_BIT
+        // Per the datasheet the temperature and limit registers are
+        // left-aligned 12-bit signed values: the LSB is the bit at
+        // position 4 (0.0625 °C/LSB) and bits 3..0 are reserved=0.
+        // Compute the conversion as a single multiplication by
+        // CELSIUS_PER_BIT/16 (== 1/256 = 0.003_906_25, exactly
+        // representable in f32) instead of dividing by 16 first via
+        // integer division.
+        //
+        // For datasheet-conforming inputs (bits 3..0 == 0) this returns
+        // exactly the same f32 as before. For any non-zero low bits it
+        // returns the correct value instead of truncating toward zero
+        // (which was asymmetric for negative inputs).
+        f32::from(t) * (Self::CELSIUS_PER_BIT / 16.0)
     }
 
     /// Convert a temperature in degrees Celsius to the raw 12-bit signed
@@ -1315,7 +1327,6 @@ mod tests {
             assert_eq!(tmp.addr(), 0x48);
             let mut mock = tmp.destroy();
             mock.done();
-
             let mock = Mock::new(&expectations);
             let tmp = Tmp108::new_with_a0_vplus(mock);
             assert_eq!(tmp.addr(), 0x49);
@@ -1516,6 +1527,33 @@ mod tests {
 
             let mut mock = tmp108.destroy();
             mock.done();
+        }
+
+        #[test]
+        fn to_celsius_is_symmetric_around_zero() {
+            // For datasheet-conforming inputs (bits 3..0 == 0) the
+            // conversion is identical to the previous integer-division
+            // implementation. For inputs with non-zero low bits the new
+            // implementation no longer truncates toward zero, which was
+            // asymmetric for negative values.
+            //
+            // 0xFFFF as i16 = -1. Old code: f32::from(-1 / 16) * 0.0625 =
+            // f32::from(0) * 0.0625 = 0.0. New code: f32::from(-1) *
+            // (0.0625 / 16.0) = -0.003_906_25.
+            let cases: &[(i16, f32)] = &[
+                (0x0000, 0.0),
+                (0x0010, 0.0625),
+                (0xFFF0_u16 as i16, -0.0625),
+                (0x7FF0, 127.9375),
+                (0xC900_u16 as i16, -55.0),
+                // Non-zero low bits: symmetric resolution.
+                (0x0001, 0.003_906_25),
+                (0xFFFF_u16 as i16, -0.003_906_25),
+            ];
+            for (raw, expected) in cases {
+                let got = Tmp108::<Mock>::to_celsius(*raw);
+                assert_approx_eq!(got, *expected, 1e-5);
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -643,11 +643,33 @@ impl<I2C: AsyncI2c> Tmp108<I2C> {
     }
 
     #[cfg(feature = "async")]
-    /// Initiate continuous conversions
+    /// Initiate continuous conversions.
+    ///
+    /// Switches the chip into [`Mode::Continuous`], runs the user-supplied
+    /// closure, and unconditionally returns the chip to [`Mode::Shutdown`]
+    /// before returning, **regardless of whether the closure succeeded or
+    /// failed**. This ensures the chip is not left burning current after
+    /// a transient bus failure inside the closure.
+    ///
+    /// # Cancel-safety
+    ///
+    /// **The returned future is *not* cancel-safe.** If it is dropped
+    /// before completion (e.g. by `embassy_futures::select!`,
+    /// `tokio::time::timeout`, or a task cancellation), the chip is left
+    /// in [`Mode::Continuous`] and will continue to draw current
+    /// indefinitely. Callers that need cancellation must structure their
+    /// own recovery, for example by calling
+    /// [`shutdown`][Self::shutdown] after a cancelled call.
     ///
     /// # Errors
     ///
-    /// `I2C::Error` when the I2C transaction fails
+    /// - If the closure returns `Err(e)`, the cleanup `shutdown()` still
+    ///   runs but its result is discarded; the closure's error is
+    ///   returned.
+    /// - If the closure returns `Ok(())` and the cleanup `shutdown()`
+    ///   fails, that I2C error is returned.
+    /// - If the initial transition into `Mode::Continuous` fails, the
+    ///   closure is not invoked and the I2C error is returned.
     ///
     /// # Examples
     ///
@@ -683,8 +705,14 @@ impl<I2C: AsyncI2c> Tmp108<I2C> {
             .modify_async(|r| r.set_m(Mode::Continuous))
             .await?;
 
-        f(self).await?;
-        self.shutdown().await
+        // Run the user closure and capture its result, but always attempt
+        // shutdown afterwards so the chip is not left in Continuous mode.
+        // The closure's error takes precedence over a shutdown failure:
+        // the user's failure is the actionable signal, the cleanup error
+        // is a secondary symptom.
+        let user_result = f(self).await;
+        let cleanup_result = self.shutdown().await;
+        user_result.and(cleanup_result)
     }
 
     /// Wait for conversion to complete. This method will block for the amount
@@ -1689,6 +1717,78 @@ mod tests {
                 assert!(matches!(tmp108.set_low_limit(bad).await, Err(Error::InvalidInput)));
                 assert!(matches!(tmp108.set_high_limit(bad).await, Err(Error::InvalidInput)));
             }
+
+            let mut mock = tmp108.destroy();
+            mock.done();
+        }
+
+        #[tokio::test]
+        async fn continuous_runs_shutdown_when_closure_returns_err() {
+            // Expectations:
+            //  1. Enter Continuous: read cfg, write cfg with M=Continuous.
+            //  2. Closure causes one temperature read that returns a bus error.
+            //  3. Cleanup must still run: read cfg, write cfg with M=Shutdown.
+            //
+            // If the cleanup is skipped (the pre-fix behavior) the mock will
+            // panic at destroy() because the last two expectations were not
+            // consumed.
+            let expectations = vec![
+                Transaction::write_read(0x48, vec![0x01], vec![0x22, 0x10]),
+                Transaction::write(0x48, vec![0x01, 0x22, 0x10]),
+                Transaction::write_read(0x48, vec![0x00], vec![0x32, 0x00])
+                    .with_error(embedded_hal::i2c::ErrorKind::Other),
+                Transaction::write_read(0x48, vec![0x01], vec![0x22, 0x10]),
+                Transaction::write(0x48, vec![0x01, 0x20, 0x10]),
+            ];
+            let mock = Mock::new(&expectations);
+            let mut tmp108 = Tmp108::new_with_a0_gnd(mock);
+
+            let result = tmp108
+                .continuous(async |t| {
+                    let _ = t.temperature().await?;
+                    Ok(())
+                })
+                .await;
+
+            // The closure's error must be propagated (closure error wins
+            // over shutdown success).
+            assert!(result.is_err());
+
+            // All five expected transactions consumed -> the cleanup
+            // shutdown ran.
+            let mut mock = tmp108.destroy();
+            mock.done();
+        }
+
+        #[tokio::test]
+        async fn continuous_returns_closure_error_when_shutdown_also_fails() {
+            use embedded_hal_async::i2c::Error as _;
+
+            // Closure fails AND shutdown fails. The closure's error must win.
+            let closure_err = embedded_hal::i2c::ErrorKind::Bus;
+            let shutdown_err = embedded_hal::i2c::ErrorKind::ArbitrationLoss;
+
+            let expectations = vec![
+                // Enter Continuous.
+                Transaction::write_read(0x48, vec![0x01], vec![0x22, 0x10]),
+                Transaction::write(0x48, vec![0x01, 0x22, 0x10]),
+                // Closure errors.
+                Transaction::write_read(0x48, vec![0x00], vec![0x32, 0x00]).with_error(closure_err),
+                // Shutdown read errors too.
+                Transaction::write_read(0x48, vec![0x01], vec![0x22, 0x10]).with_error(shutdown_err),
+            ];
+            let mock = Mock::new(&expectations);
+            let mut tmp108 = Tmp108::new_with_a0_gnd(mock);
+
+            let result = tmp108
+                .continuous(async |t| {
+                    let _ = t.temperature().await?;
+                    Ok(())
+                })
+                .await;
+
+            // Must propagate the closure error, not the shutdown error.
+            assert_eq!(result.err().map(|e| e.kind()), Some(closure_err));
 
             let mut mock = tmp108.destroy();
             mock.done();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,6 +424,68 @@ impl<I2C: embedded_hal_async::i2c::I2c, ALERT: embedded_hal_async::digital::Wait
 impl<I2C: AsyncI2c> Tmp108<I2C> {
     const CELSIUS_PER_BIT: f32 = 0.0625;
 
+    /// Probe the chip's presence by reading the configuration register.
+    ///
+    /// The TMP108 does not expose a `WHO_AM_I` / device-ID register, so a
+    /// true identity probe is impossible. This method does the next-best
+    /// thing: it reads the configuration register and reports whether
+    /// the value matches the chip's documented power-on reset (POR)
+    /// value `0x1022`. Useful immediately after power-on to confirm the
+    /// chip is freshly out of reset and on the bus.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(true)` — the read succeeded and the configuration register
+    ///   matches the POR value. Strong evidence the chip is present and
+    ///   has not yet been reconfigured.
+    /// - `Ok(false)` — the read succeeded but the configuration differs
+    ///   from POR. Still strong evidence the chip is present (it `ACKed`
+    ///   and returned plausible register data) but it was already
+    ///   reconfigured since power-on. False negatives are unavoidable on
+    ///   any boot path where the chip was configured before this method
+    ///   ran.
+    /// - `Err(_)` — the I2C read failed. Most likely cause is that no
+    ///   chip is present at the expected address (NACK), but any bus
+    ///   error reports here as well.
+    ///
+    /// # Errors
+    ///
+    /// `I2C::Error` when the I2C read fails.
+    ///
+    /// (Doctest runs against the blocking API; the async variant has the same
+    /// shape with `.await` after the call.)
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use embedded_hal_mock::eh1::i2c::{Mock, Transaction};
+    /// # #[cfg(feature = "async")] fn main() {}
+    /// # #[cfg(not(feature = "async"))]
+    /// # fn main() {
+    /// use tmp108::Tmp108;
+    /// // Chip returns the POR configuration -> probe() reports true.
+    /// let i2c = Mock::new(&[
+    ///     Transaction::write_read(0x48, vec![0x01], vec![0x22, 0x10]),
+    /// ]);
+    /// let mut tmp = Tmp108::new_with_a0_gnd(i2c);
+    /// assert!(tmp.probe().unwrap());
+    /// # let mut i2c = tmp.destroy();
+    /// # i2c.done();
+    /// # }
+    /// ```
+    pub async fn probe(&mut self) -> Result<bool, I2C::Error> {
+        /// TMP108 configuration register reset value, per the datasheet.
+        const POR: u16 = 0x1022;
+
+        #[cfg(feature = "async")]
+        let raw = self.inner.configuration().read_async().await?;
+
+        #[cfg(not(feature = "async"))]
+        let raw = self.inner.configuration().read()?;
+
+        Ok(u16::from_le_bytes(raw.into()) == POR)
+    }
+
     /// Read configuration register
     ///
     /// # Errors
@@ -1584,6 +1646,48 @@ mod tests {
                 assert_approx_eq!(got, *expected, 1e-5);
             }
         }
+
+        #[test]
+        fn probe_returns_true_for_por_value() {
+            // Configuration register at 0x01 returns the POR value 0x1022.
+            // The register layout is little-endian per tmp108.toml so the
+            // wire bytes are [0x22, 0x10].
+            let expectations = vec![Transaction::write_read(0x48, vec![0x01], vec![0x22, 0x10])];
+            let mock = Mock::new(&expectations);
+            let mut tmp108 = Tmp108::new_with_a0_gnd(mock);
+
+            assert_eq!(tmp108.probe(), Ok(true));
+
+            let mut mock = tmp108.destroy();
+            mock.done();
+        }
+
+        #[test]
+        fn probe_returns_false_for_non_por_value() {
+            // Chip is present (ACKs) but has been reconfigured.
+            let expectations = vec![Transaction::write_read(0x48, vec![0x01], vec![0x66, 0xb0])];
+            let mock = Mock::new(&expectations);
+            let mut tmp108 = Tmp108::new_with_a0_gnd(mock);
+
+            assert_eq!(tmp108.probe(), Ok(false));
+
+            let mut mock = tmp108.destroy();
+            mock.done();
+        }
+
+        #[test]
+        fn probe_propagates_bus_error() {
+            let expectations = vec![Transaction::write_read(0x48, vec![0x01], vec![0x22, 0x10]).with_error(
+                embedded_hal::i2c::ErrorKind::NoAcknowledge(embedded_hal::i2c::NoAcknowledgeSource::Address),
+            )];
+            let mock = Mock::new(&expectations);
+            let mut tmp108 = Tmp108::new_with_a0_gnd(mock);
+
+            assert!(tmp108.probe().is_err());
+
+            let mut mock = tmp108.destroy();
+            mock.done();
+        }
     }
 
     #[cfg(feature = "async")]
@@ -1800,6 +1904,30 @@ mod tests {
                 assert!(matches!(tmp108.set_low_limit(bad).await, Err(Error::InvalidInput)));
                 assert!(matches!(tmp108.set_high_limit(bad).await, Err(Error::InvalidInput)));
             }
+
+            let mut mock = tmp108.destroy();
+            mock.done();
+        }
+
+        #[tokio::test]
+        async fn probe_returns_true_for_por_value() {
+            let expectations = vec![Transaction::write_read(0x48, vec![0x01], vec![0x22, 0x10])];
+            let mock = Mock::new(&expectations);
+            let mut tmp108 = Tmp108::new_with_a0_gnd(mock);
+
+            assert_eq!(tmp108.probe().await, Ok(true));
+
+            let mut mock = tmp108.destroy();
+            mock.done();
+        }
+
+        #[tokio::test]
+        async fn probe_returns_false_for_non_por_value() {
+            let expectations = vec![Transaction::write_read(0x48, vec![0x01], vec![0x66, 0xb0])];
+            let mock = Mock::new(&expectations);
+            let mut tmp108 = Tmp108::new_with_a0_gnd(mock);
+
+            assert_eq!(tmp108.probe().await, Ok(false));
 
             let mut mock = tmp108.destroy();
             mock.done();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1028,18 +1028,26 @@ impl<I2C: AsyncI2c> AsyncRegisterInterface for Interface<I2C> {
 }
 
 /// Tmp108 Errors
+///
+/// The `E` parameter is the underlying I2C error type. The `P` parameter
+/// is the error type of an optional ALERT GPIO pin; it defaults to
+/// [`core::convert::Infallible`] so bare [`Tmp108`] (which has no pin)
+/// uses `Error<I2C::Error>` and never produces a [`Pin`][Self::Pin]
+/// error. [`AlertTmp108`] specializes to
+/// `Error<I2C::Error, ALERT::Error>` and uses the [`Pin`][Self::Pin]
+/// variant when the GPIO peripheral fails.
 #[derive(Debug)]
-pub enum Error<E: embedded_hal::i2c::Error> {
-    /// I2C Bus Error
+pub enum Error<E: embedded_hal::i2c::Error, P: embedded_hal::digital::Error = core::convert::Infallible> {
+    /// I2C bus error.
     Bus(E),
-    /// Invalid Input Error
+    /// Input failed validation (out of range, NaN, ±∞, unsupported value).
     InvalidInput,
-    /// Other Error
-    Other,
+    /// ALERT pin GPIO error.
+    Pin(P),
 }
 
 #[cfg(all(feature = "embedded-sensors-hal", not(feature = "async")))]
-impl<E: embedded_hal::i2c::Error> embedded_sensors_hal::sensor::Error for Error<E> {
+impl<E: embedded_hal::i2c::Error, P: embedded_hal::digital::Error> embedded_sensors_hal::sensor::Error for Error<E, P> {
     fn kind(&self) -> embedded_sensors_hal::sensor::ErrorKind {
         embedded_sensors_hal::sensor::ErrorKind::Other
     }
@@ -1058,7 +1066,9 @@ impl<I2C: embedded_hal::i2c::I2c> embedded_sensors_hal::temperature::Temperature
 }
 
 #[cfg(all(feature = "embedded-sensors-hal-async", feature = "async"))]
-impl<E: embedded_hal_async::i2c::Error> embedded_sensors_hal_async::sensor::Error for Error<E> {
+impl<E: embedded_hal_async::i2c::Error, P: embedded_hal::digital::Error> embedded_sensors_hal_async::sensor::Error
+    for Error<E, P>
+{
     fn kind(&self) -> embedded_sensors_hal_async::sensor::ErrorKind {
         embedded_sensors_hal_async::sensor::ErrorKind::Other
     }
@@ -1080,7 +1090,7 @@ impl<I2C: embedded_hal_async::i2c::I2c> embedded_sensors_hal_async::temperature:
 impl<I2C: embedded_hal_async::i2c::I2c, ALERT: embedded_hal_async::digital::Wait + embedded_hal::digital::InputPin>
     embedded_sensors_hal_async::sensor::ErrorType for AlertTmp108<I2C, ALERT>
 {
-    type Error = Error<I2C::Error>;
+    type Error = Error<I2C::Error, <ALERT as embedded_hal::digital::ErrorType>::Error>;
 }
 
 #[cfg(all(feature = "embedded-sensors-hal-async", feature = "async"))]
@@ -1119,14 +1129,16 @@ impl<I2C: embedded_hal_async::i2c::I2c, ALERT: embedded_hal_async::digital::Wait
         &mut self,
         threshold: embedded_sensors_hal_async::temperature::DegreesCelsius,
     ) -> Result<(), Self::Error> {
-        self.tmp108.set_low_limit(threshold).await
+        // Bare-Tmp108 set_*_limit returns Error<I2C::Error>; widen the Pin
+        // type parameter to the AlertTmp108-flavored Error.
+        self.tmp108.set_low_limit(threshold).await.map_err(widen_pin_err)
     }
 
     async fn set_temperature_threshold_high(
         &mut self,
         threshold: embedded_sensors_hal_async::temperature::DegreesCelsius,
     ) -> Result<(), Self::Error> {
-        self.tmp108.set_high_limit(threshold).await
+        self.tmp108.set_high_limit(threshold).await.map_err(widen_pin_err)
     }
 }
 
@@ -1148,10 +1160,10 @@ impl<I2C: embedded_hal_async::i2c::I2c, ALERT: embedded_hal_async::digital::Wait
             // ALERT pin only resets when temperature falls within the range of (Tlow + HYS) and
             // (Thigh - HYS).
             (Thermostat::Comparator, Polarity::ActiveLow) => {
-                self.alert.wait_for_low().await.map_err(|_| Error::Other)?;
+                self.alert.wait_for_low().await.map_err(Error::Pin)?;
             }
             (Thermostat::Comparator, Polarity::ActiveHigh) => {
-                self.alert.wait_for_high().await.map_err(|_| Error::Other)?;
+                self.alert.wait_for_high().await.map_err(Error::Pin)?;
             }
 
             // In interrupt mode, the ALERT pin is immediately reset (by reading config register)
@@ -1160,11 +1172,11 @@ impl<I2C: embedded_hal_async::i2c::I2c, ALERT: embedded_hal_async::digital::Wait
             // If called in a loop, next iteration would wait even if temperature remains outside
             // threshold.
             (Thermostat::Interrupt, Polarity::ActiveLow) => {
-                self.alert.wait_for_falling_edge().await.map_err(|_| Error::Other)?;
+                self.alert.wait_for_falling_edge().await.map_err(Error::Pin)?;
                 let _ = self.tmp108.read_configuration().await.map_err(Error::Bus)?;
             }
             (Thermostat::Interrupt, Polarity::ActiveHigh) => {
-                self.alert.wait_for_rising_edge().await.map_err(|_| Error::Other)?;
+                self.alert.wait_for_rising_edge().await.map_err(Error::Pin)?;
                 let _ = self.tmp108.read_configuration().await.map_err(Error::Bus)?;
             }
         }
@@ -1213,7 +1225,7 @@ impl<I2C: embedded_hal_async::i2c::I2c> embedded_sensors_hal_async::temperature:
             return Err(Error::InvalidInput);
         }
 
-        let mut config = self.read_configuration().await.map_err(|_| Error::Other)?;
+        let mut config = self.read_configuration().await.map_err(Error::Bus)?;
         config.hysteresis = snapped;
         self.configure(config).await.map_err(Error::Bus)
     }
@@ -1227,7 +1239,24 @@ impl<I2C: embedded_hal_async::i2c::I2c, ALERT: embedded_hal_async::digital::Wait
         &mut self,
         hysteresis: embedded_sensors_hal_async::temperature::DegreesCelsius,
     ) -> Result<(), Self::Error> {
-        self.tmp108.set_temperature_threshold_hysteresis(hysteresis).await
+        self.tmp108
+            .set_temperature_threshold_hysteresis(hysteresis)
+            .await
+            .map_err(widen_pin_err)
+    }
+}
+
+/// Widen an `Error<E>` (with Pin = Infallible) to `Error<E, P>` for any
+/// `P`. Used by the `AlertTmp108` trait impls that delegate to bare
+/// `Tmp108` methods (which cannot themselves produce a `Pin` error).
+#[cfg(all(feature = "embedded-sensors-hal-async", feature = "async"))]
+fn widen_pin_err<E: embedded_hal_async::i2c::Error, P: embedded_hal::digital::Error>(
+    e: Error<E, core::convert::Infallible>,
+) -> Error<E, P> {
+    match e {
+        Error::Bus(e) => Error::Bus(e),
+        Error::InvalidInput => Error::InvalidInput,
+        Error::Pin(never) => match never {},
     }
 }
 
@@ -1988,6 +2017,51 @@ mod tests {
 
             let mut mock = tmp108.destroy();
             mock.done();
+        }
+
+        #[cfg(feature = "embedded-sensors-hal-async")]
+        #[tokio::test]
+        async fn alert_pin_error_is_propagated_as_error_pin() {
+            use embedded_hal_mock::eh1::{MockError, digital};
+            use embedded_sensors_hal_async::temperature::TemperatureThresholdWait;
+
+            // Configure for Interrupt + ActiveLow so wait_for_falling_edge
+            // is the gating operation. The pin then errors; the driver
+            // must surface the GPIO error via Error::Pin(_), not swallow
+            // it (the pre-fix behavior collapsed all GPIO failures to
+            // Error::Other).
+            let i2c_expectations = vec![
+                // configure: read + write
+                Transaction::write_read(0x48, vec![0x01], vec![0x22, 0x10]),
+                Transaction::write(0x48, vec![0x01, 0x26, 0x10]),
+                // wait_for_temperature_threshold reads cfg first
+                Transaction::write_read(0x48, vec![0x01], vec![0x26, 0x10]),
+            ];
+            let i2c_mock = Mock::new(&i2c_expectations);
+
+            let pin_err = MockError::Io(std::io::ErrorKind::Other);
+            let pin_expectations =
+                vec![digital::Transaction::wait_for_edge(digital::Edge::Falling).with_error(pin_err.clone())];
+            let pin_mock = digital::Mock::new(&pin_expectations);
+
+            let mut tmp108 = AlertTmp108::new_with_a0_gnd(i2c_mock, pin_mock);
+
+            let cfg = Config {
+                thermostat_mode: Thermostat::Interrupt,
+                alert_polarity: Polarity::ActiveLow,
+                ..Default::default()
+            };
+            tmp108.tmp108.configure(cfg).await.unwrap();
+
+            let result = tmp108.wait_for_temperature_threshold().await;
+            match result {
+                Err(Error::Pin(e)) => assert_eq!(e, pin_err),
+                other => panic!("expected Error::Pin, got {other:?}"),
+            }
+
+            let (mut i2c_mock, mut pin_mock) = tmp108.destroy();
+            i2c_mock.done();
+            pin_mock.done();
         }
     }
 }


### PR DESCRIPTION
## Summary

Reliability-focused 0.6.0 release. Closes the operational hazards
surfaced by an `@reliability` review of the 0.5.0 driver — three of
those are addressed with breaking changes that are mechanical to
migrate, the rest are non-breaking behavior fixes or documentation
contracts. The architectural restructuring (typestate / two named
types `Tmp108` + `AsyncTmp108`) the parallel `@architect` review
recommended is **explicitly deferred** to a separate follow-up PR
against this branch.

Design spec at
[`docs/superpowers/specs/2026-06-03-tmp108-reliability-fixes-design.md`](https://github.com/felipebalbi/tmp108/blob/reliability-fixes/docs/superpowers/specs/2026-06-03-tmp108-reliability-fixes-design.md)
captures every decision and the migration matrix.

## What changes (per commit)

| Commit | Finding | Scope | Breaking? |
|---|---|---|---|
| `docs: add design spec for reliability fixes (0.6.0)` | — | spec only | no |
| `feat!: validate set_low_limit/set_high_limit inputs` | **C3** silent f32 saturation | `set_*_limit` rejects NaN/±∞/out-of-range with `Error::InvalidInput`; return type becomes `Result<(), Error<I2C::Error>>` | **yes** |
| `fix: run shutdown() in continuous() on both success and error paths` | **C2** chip left in Continuous on closure `Err`; **C1** docs | `shutdown()` runs unconditionally; closure error wins; `continuous()` documented as not cancel-safe | no (behavior change) |
| `fix: snap hysteresis input to nearest legal value within 0.05C tolerance` | **H5** `f32::EPSILON` too strict | hysteresis snaps within 0.05 °C of {0,1,2,4}; reject non-finite and out-of-band | no (behavior change — accepts more) |
| `refactor: remove integer division from to_celsius` | **M5** asymmetric truncation | single multiply by `CELSIUS_PER_BIT/16` | no |
| `feat!: replace Error::Other with Error::Pin generic over ALERT::Error` | **H6** swallowed GPIO error | `Error<E, P = Infallible>` with `Pin(P)` variant; `AlertTmp108` uses `Error<I2C::Error, ALERT::Error>` | **yes** |
| `feat: add Tmp108::probe() to confirm chip presence` | **M2** | new `probe() -> Result<bool, I2C::Error>` (POR match / non-POR / bus err) | no |
| `docs: cancel-safety, lifecycle, concurrency, and stale-read warnings` | **H1, H2, H4, M1, M3, M4, M6** | crate-level + method-level doc additions | no |
| `chore: bump version to 0.6.0 and add CHANGELOG` | — | version + new `CHANGELOG.md` (Keep a Changelog format) | release |

Decisions deliberately made:

- **H1** lost-edge race: not a driver fix. The `embedded-hal-async`
  `Wait` trait handles pending edges via the MCU's GPIO controller;
  HALs that drop pending edges are non-conforming. Documented as a
  contract on `AlertTmp108`.
- **H2** Comparator busy-loop: documented. The `Wait` trait does not
  expose "wait for deassertion" cleanly, so the fix is a doc note
  steering callers to Interrupt mode or app-level backoff.
- **H3** TLow/THigh resolution verification: hardware-only; deferred.
- **M1, M3, M4, M6**: doc-only; the underlying behavior is correct
  given the documented contracts.

Architecture refactor (`@architect`'s Option B: two named types,
shared `mod ops`) is queued for the next PR.

## Migration (also in CHANGELOG)

For most downstream code only one pattern needs to change:

```rust
// Before
match tmp.set_low_limit(value) {
    Ok(()) => {}
    Err(i2c_err) => /* handle */,
}

// After
match tmp.set_low_limit(value) {
    Ok(()) => {}
    Err(Error::Bus(i2c_err)) => /* handle bus error */,
    Err(Error::InvalidInput) => /* new — handle invalid f32 */,
}
```

Pattern matches on `Error::Other` need to switch to `Error::Pin(_)`
for GPIO failures. `AlertTmp108`'s `Self::Error` becomes
`Error<I2C::Error, ALERT::Error>` (default `P = Infallible` makes
`Tmp108<I2C>` continue to typecheck without spelling out a second
parameter).

## Test coverage

Every fix lands with a focused regression test in the same commit:

- `reject_invalid_set_limit_inputs` ×2 — pins range/NaN/Inf rejection
- `continuous_runs_shutdown_when_closure_returns_err` — pins cleanup
  on closure failure
- `continuous_returns_closure_error_when_shutdown_also_fails` — pins
  the closure-wins precedence with distinct `ErrorKind`s
- `hysteresis_snaps_within_tolerance` + `hysteresis_rejects_out_of_tolerance_and_non_finite`
- `to_celsius_is_symmetric_around_zero` — pins the non-zero-low-bits
  improvement
- `alert_pin_error_is_propagated_as_error_pin` — triggers a real GPIO
  error via `with_error()` and verifies `Error::Pin(MockError)` is
  surfaced (not swallowed to `Other`)
- `probe_returns_true_for_por_value` / `probe_returns_false_for_non_por_value`
  / `probe_propagates_bus_error` ×2 modules

Note: previously broken (before PR1) tests using the old
`f32::EPSILON` snapping or unbounded `to_raw` truncation could not be
written cleanly because they depended on now-fixed behavior.

## Local matrix verified

Per AGENTS.md, all of the canonical local matrix runs green on this
branch (against today's `upstream/main`):

- `cargo +nightly fmt --check`
- `cargo clippy --all-features --all-targets -- -W clippy::suspicious -W clippy::correctness -W clippy::perf -W clippy::style`
- `cargo doc --no-deps --all-features --locked`
- `cargo test --locked` × 3 feature combos
- `cargo build --examples --locked` × 4 feature combos
- `cargo hack --feature-powerset check --locked` (8/8 combos)
- `./scripts/check-readme-snippets.sh` (3/3 match)
- `cargo vet --locked` (177 audited)

`cargo-semver-checks` not installed locally — CI will flag the two
breaking changes and confirm the 0.6.0 bump matches.

Hardware verification was **not** performed for this PR. The fixes
touch I²C error paths and ALERT-pin error mapping but not the
ALERT-pin wire-level behavior; per AGENTS.md "mandatory for any
change that touches alert-pin behavior" I'd value a hands-on
verification pass on `alert_interrupt` / `alert_comparator` against
the Pico de Gallo before merge.

## Risks called out in the spec

1. **H6 blast radius.** Every downstream match on `Error::Other`
   breaks. The new `Pin` variant is the right semantic fix; migration
   is mechanical and the CHANGELOG covers it.
2. **C2 behavior change.** Users who deliberately wanted the chip to
   stay in Continuous after a closure failure (to inspect state) will
   need to call `configure(...)` explicitly. The new default matches
   the safer expectation and is called out in the CHANGELOG.
3. **Binary-breaking `Error` parameter addition.** `cargo-semver-checks`
   will flag it as major; that's why this PR bumps minor (the crate is
   pre-1.0).

## Out of scope

Tracked for follow-up PR(s):

- Type-split refactor to `Tmp108` (blocking) + `AsyncTmp108` (async),
  shared `mod ops`, drop `maybe-async-cfg`. **Already drafted as a
  follow-up branch** in this fork (`named-types`); will be opened as a
  separate PR after this one is integrated.
- TMP108 TLow/THigh resolution verification on real hardware (H3).
- Diagnostic counters / sticky flags (L5).

## Conventional Commits compliance

Every commit follows
[Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).
Breaking commits have a `!` after the type and a `BREAKING CHANGE:`
footer. Every commit ends with an
`Assisted-by: opencode:claude-opus-4.7-1m-internal` trailer per
AGENTS.md.
